### PR TITLE
Add build to upload lambda changes

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+steps:
+  - label: "Publish share_snapshots_rds lambda"
+    # Note, Buildkite passes the script around as an ENV VAR so any local variables
+    # need to be escaped
+    command: |
+      cd lambda
+      for component in take share delete_old; do
+        for region in us-east-1 us-west-1 us-west-2; do
+          make \
+            S3DEST=$ARTIFACTS_BUCKET_PREFIX-\$region/rds-snapshot-tool/\$(echo \$component | tr '_' '-')-snapshots/$BUILDKITE_COMMIT.zip \
+            AWSARGS="--region \$region" \
+            ._\${component}_snapshots_rds
+        done
+      done
+    # branches: "root-feature"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,4 +12,4 @@ steps:
             ._\${component}_snapshots_rds
         done
       done
-    # branches: "root-feature"
+    branches: "root-features"

--- a/cftemplates/snapshots_tool_rds_source.json
+++ b/cftemplates/snapshots_tool_rds_source.json
@@ -18,6 +18,21 @@
 			"Default": "DEFAULT_BUCKET",
 			"Description": "Name of the bucket that contains the lambda functions to deploy. Leave the default value to download the code from the AWS Managed buckets"
 		},
+		"TakeLambdaCodeBucketKey": {
+		        "Type": "String",
+		        "Default": "take_snapshots_rds.zip",
+		        "Description": "S3 key for the take_snapshots lambda"
+		},
+		"ShareLambdaCodeBucketKey": {
+		        "Type": "String",
+		        "Default": "share_snapshots_rds.zip",
+		        "Description": "S3 key for the share_snapshots lambda"
+		},
+		"DeleteOldLambdaCodeBucketKey": {
+		        "Type": "String",
+		        "Default": "delete_old_snapshots_rds.zip",
+		        "Description": "S3 key for the delete_old_snapshots lambda"
+		},
 		"InstanceNamePattern": {
 			"Type": "String",
 			"Default": "ALL_INSTANCES",
@@ -399,7 +414,7 @@
 							"Ref": "CodeBucket"
 						}]
 					},
-					"S3Key": "take_snapshots_rds.zip"
+					"S3Key": {"Ref": "TakeLambdaCodeBucketKey"}
 				},
 				"MemorySize" : 512,
 				"Description": "This functions triggers snapshots creation for RDS instances. It checks for existing snapshots following the pattern and interval specified in the environment variables with the following format: <dbinstancename>-YYYY-MM-DD-HH-MM",
@@ -444,7 +459,7 @@
 							"Ref": "CodeBucket"
 						}]
 					},
-					"S3Key": "share_snapshots_rds.zip"
+					"S3Key": {"Ref": "ShareLambdaCodeBucketKey"}
 				},
 				"MemorySize" : 512,
 				"Description": "This function shares snapshots created by the take_snapshots_rds function with DEST_ACCOUNTS specified in the environment variables. ",
@@ -486,7 +501,7 @@
 							"Ref": "CodeBucket"
 						}]
 					},
-					"S3Key": "delete_old_snapshots_rds.zip"
+					"S3Key": {"Ref": "DeleteOldLambdaCodeBucketKey"}
 				},
 				"MemorySize" : 512,
 				"Description": "This function deletes snapshots created by the take_snapshots_rds function. ",


### PR DESCRIPTION
We never set up the publishing wiring to use our changes. This adds a Buildkite build to create the artifact and upload to S3 and some changes to the CFN stack to take the appropriate key in